### PR TITLE
Removes ghproxy proxy for resource links

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,8 +29,8 @@ export default defineConfig({
                 contributionURL: 'https://github.com/KeyPJ/seelieEx',
                 connect: ['api-takumi.mihoyo.com', 'public-data-api.mihoyo.com'],
                 resource: {
-                    character: "https://ghproxy.com/https://raw.githubusercontent.com/KeyPJ/seelieEx/main/src/data/character.json",
-                    weapon: "https://ghproxy.com/https://raw.githubusercontent.com/KeyPJ/seelieEx/main/src/data/weapon.json"
+                    character: "https://raw.githubusercontent.com/KeyPJ/seelieEx/main/src/data/character.json",
+                    weapon: "https://raw.githubusercontent.com/KeyPJ/seelieEx/main/src/data/weapon.json"
                 },
                 "run-at": "document-end",
                 homepage: "https://github.com/KeyPJ",


### PR DESCRIPTION
今天在新电脑上安装脚本后，在Tampemonkey菜单中没有找到“打开SeelieEx”的选项。一番排查，发现是`https://ghproxy.link/`的代理地址过期了（访问资源链接会被重定向到其主页）。

此PR移除了`https://ghproxy.link/`的使用，改为使用原始的github链接，主要是考虑

1. `https://ghproxy.link/`因被屏蔽已经更换过多次域名，虽然当前有可用的地址，但不确定新地址什么时候又会被屏蔽
2. seelieEx的主要发布渠道，目前应该只有`github`和`jsdelivr.net`，都需要代理访问。能访问到脚本页面的用户，通常不会有网络上的困难，但是排查定位脚本问题需要js相关知识，特别是初次使用脚本的用户可能都不知道正常工作时应该是什么状态